### PR TITLE
Add comprehensive container metrics support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,6 @@ PUBLISH_INTERVAL=120
 # Optional: Container filtering
 # INCLUDE_ONLY=container1,container2,container3
 # EXCLUDE_ONLY=container_to_ignore
+
+# Optional: Enable container metrics (CPU, memory, network, disk)
+# ENABLE_METRICS=true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,9 @@ This project monitors Docker containers and publishes their status to MQTT for H
 
 ## Key Features
 - Monitors container status (running/stopped)
+- Tracks container resource metrics (CPU, memory, network, disk I/O) with ENABLE_METRICS
 - Creates Home Assistant switch entities via MQTT auto-discovery
+- Creates Home Assistant sensor entities for metrics when enabled
 - Allows remote container control (start/stop)
 - Container filtering with INCLUDE_ONLY/EXCLUDE_ONLY
 
@@ -21,6 +23,7 @@ This project monitors Docker containers and publishes their status to MQTT for H
 - PUBLISH_INTERVAL: Status update frequency (default: 60s)
 - INCLUDE_ONLY: Comma-separated list of containers to monitor
 - EXCLUDE_ONLY: Comma-separated list of containers to ignore
+- ENABLE_METRICS: Enable container resource metrics (CPU, memory, network, disk)
 
 ## Development Commands
 ```bash
@@ -74,6 +77,13 @@ docker logs docker-status-mqtt-homeassistant
 - Docker Compose supports platform specifications for local builds
 - Users on ARM devices (Raspberry Pi, etc.) can use the same image
 
+## Container Metrics System
+- **ENABLE_METRICS**: Optional feature to track resource usage
+- **Supported Metrics**: CPU %, memory %, memory usage (MB), network RX/TX (MB), disk read/write (MB)
+- **Home Assistant Integration**: Creates sensor entities with appropriate device classes and state classes
+- **Multi-Mode Support**: Works with Docker socket, SSH, and local command execution
+- **Performance**: Metrics collected only for running containers during regular status updates
+
 ## Future Enhancements Priority
-1. Add container metrics (CPU, memory, disk, network)
-2. Add comprehensive test coverage
+1. Add comprehensive test coverage for main.py and config.py
+2. Async architecture with aiomqtt/aiodocker for better performance

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Monitor and control your Docker containers through Home Assistant via MQTT.
 This container publishes the status of your Docker containers to an MQTT broker and creates Home Assistant switch entities for each container. It allows you to:
 
 - **Monitor** container states (running/stopped) in real-time
+- **Track** container resource metrics (CPU, memory, network, disk I/O)
 - **Control** containers (start/stop) directly from Home Assistant
 - **Filter** which containers to monitor using include/exclude lists
 - **Auto-exclude** the monitoring container itself from the list
@@ -47,6 +48,7 @@ docker run -d \
 | `PUBLISH_INTERVAL` | Status update interval (seconds) | 60 | No |
 | `INCLUDE_ONLY` | Comma-separated container names to monitor | - | No |
 | `EXCLUDE_ONLY` | Comma-separated container names to exclude | - | No |
+| `ENABLE_METRICS` | Enable container metrics (CPU, memory, network, disk) | false | No |
 
 **Note**: The monitoring container automatically excludes itself from the list to prevent self-monitoring.
 
@@ -71,6 +73,16 @@ docker run -d \
   -e MQTT_SERVER=192.168.1.100 \
   -e MQTT_USER=homeassistant \
   -e MQTT_PASSWORD=mypassword \
+  pcarorevuelta/docker-status-mqtt-homeassistant
+```
+
+### Enable Container Metrics
+```bash
+docker run -d \
+  --name docker-status-mqtt \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -e MQTT_SERVER=192.168.1.100 \
+  -e ENABLE_METRICS=true \
   pcarorevuelta/docker-status-mqtt-homeassistant
 ```
 
@@ -121,6 +133,7 @@ services:
       - MQTT_USER=homeassistant
       - MQTT_PASSWORD=mypassword
       - PUBLISH_INTERVAL=30
+      - ENABLE_METRICS=true
 ```
 
 ## Home Assistant Integration
@@ -143,9 +156,21 @@ The switches will appear in Home Assistant under MQTT integration with the abili
 
 ## MQTT Topics
 
-- **State**: `homeassistant/switch/unraid_docker_{container}/state`
-- **Command**: `homeassistant/switch/unraid_docker_{container}/set`
-- **Config**: `homeassistant/switch/unraid_docker_{container}/config` (auto-discovery)
+### Container Control (Switch Entities)
+- **State**: `homeassistant/switch/{entity_prefix}{container}/state`
+- **Command**: `homeassistant/switch/{entity_prefix}{container}/set`
+- **Config**: `homeassistant/switch/{entity_prefix}{container}/config` (auto-discovery)
+
+### Container Metrics (Sensor Entities)
+When `ENABLE_METRICS=true`, additional sensor entities are created:
+
+- **CPU Usage**: `homeassistant/sensor/{entity_prefix}{container}_cpu/state` (%)
+- **Memory Usage**: `homeassistant/sensor/{entity_prefix}{container}_memory/state` (%)
+- **Memory Usage (MB)**: `homeassistant/sensor/{entity_prefix}{container}_memory_usage/state` (MB)
+- **Network RX**: `homeassistant/sensor/{entity_prefix}{container}_network_rx/state` (MB)
+- **Network TX**: `homeassistant/sensor/{entity_prefix}{container}_network_tx/state` (MB)
+- **Disk Read**: `homeassistant/sensor/{entity_prefix}{container}_disk_read/state` (MB)
+- **Disk Write**: `homeassistant/sensor/{entity_prefix}{container}_disk_write/state` (MB)
 
 ## Health Checks
 

--- a/config.py
+++ b/config.py
@@ -25,6 +25,7 @@ class Config:
         entity_name="Unraid Docker",
         entity_prefix=None,
         verbose=False,
+        enable_metrics=False,
     ):
         self.unraid_host = unraid_host or os.getenv("SSH_HOST")
         self.unraid_port = int(unraid_port or os.getenv("SSH_PORT", 22))
@@ -55,6 +56,7 @@ class Config:
         self.entity_prefix = entity_prefix
 
         self.verbose = verbose
+        self.enable_metrics = enable_metrics or os.getenv("ENABLE_METRICS", "false").lower() == "true"
 
         self.validate_config()
 

--- a/docker_manager.py
+++ b/docker_manager.py
@@ -101,6 +101,11 @@ class DockerManager(ABC):
 
     def get_container_status(self, container_name) -> str:
         return self.get_docker_statuses().get(container_name, "Not found")
+    
+    @abstractmethod
+    def get_container_stats(self, container_name) -> dict:
+        """Get container resource statistics (CPU, memory, disk, network)"""
+        pass
 
 
 class DockerCommandManager(DockerManager):
@@ -134,6 +139,98 @@ class DockerCommandManager(DockerManager):
         return self.command_executor.run_command(
             f"docker inspect --format='{{{{.State.Status}}}}' {container_name}"
         )
+    
+    def get_container_stats(self, container_name) -> dict:
+        """Get container resource statistics using docker stats command"""
+        try:
+            # Check if container is running
+            status = self.get_container_status(container_name).strip()
+            if status != 'running':
+                return {}
+            
+            # Get stats with docker stats command (no-stream for single snapshot)
+            stats_output = self.command_executor.run_command(
+                f"docker stats {container_name} --no-stream --format '{{{{.CPUPerc}}}}|{{{{.MemUsage}}}}|{{{{.MemPerc}}}}|{{{{.NetIO}}}}|{{{{.BlockIO}}}}'"
+            )
+            
+            if not stats_output:
+                return {}
+            
+            # Parse the output
+            parts = stats_output.strip().split('|')
+            if len(parts) != 5:
+                return {}
+            
+            cpu_str, mem_usage_str, mem_perc_str, net_io_str, block_io_str = parts
+            
+            # Parse CPU percentage
+            cpu_percent = float(cpu_str.rstrip('%'))
+            
+            # Parse memory usage (e.g., "1.5GiB / 8GiB")
+            mem_parts = mem_usage_str.split(' / ')
+            mem_usage = self._parse_size(mem_parts[0])
+            mem_limit = self._parse_size(mem_parts[1]) if len(mem_parts) > 1 else 0
+            mem_percent = float(mem_perc_str.rstrip('%'))
+            
+            # Parse network I/O (e.g., "1.5GB / 2.3GB")
+            net_parts = net_io_str.split(' / ')
+            net_rx = self._parse_size(net_parts[0]) if net_parts else 0
+            net_tx = self._parse_size(net_parts[1]) if len(net_parts) > 1 else 0
+            
+            # Parse block I/O (e.g., "1.5GB / 2.3GB")
+            block_parts = block_io_str.split(' / ')
+            block_read = self._parse_size(block_parts[0]) if block_parts else 0
+            block_write = self._parse_size(block_parts[1]) if len(block_parts) > 1 else 0
+            
+            return {
+                'cpu_percent': round(cpu_percent, 2),
+                'memory_usage_mb': round(mem_usage / 1024 / 1024, 2),
+                'memory_limit_mb': round(mem_limit / 1024 / 1024, 2),
+                'memory_percent': round(mem_percent, 2),
+                'network_rx_mb': round(net_rx / 1024 / 1024, 2),
+                'network_tx_mb': round(net_tx / 1024 / 1024, 2),
+                'blkio_read_mb': round(block_read / 1024 / 1024, 2),
+                'blkio_write_mb': round(block_write / 1024 / 1024, 2)
+            }
+        except Exception as e:
+            logger.error(f"Error getting stats for container {container_name}: {e}")
+            return {}
+    
+    def _parse_size(self, size_str: str) -> float:
+        """Parse size string like '1.5GiB' or '500MB' to bytes"""
+        size_str = size_str.strip()
+        if not size_str:
+            return 0
+        
+        units = [
+            ('TIB', 1024**4),
+            ('TI', 1024**4),
+            ('TB', 1024**4),
+            ('GIB', 1024**3),
+            ('GI', 1024**3),
+            ('GB', 1024**3),
+            ('MIB', 1024**2),
+            ('MI', 1024**2),
+            ('MB', 1024**2),
+            ('KIB', 1024),
+            ('KI', 1024),
+            ('KB', 1024),
+            ('B', 1)
+        ]
+        
+        for unit, multiplier in units:
+            if size_str.upper().endswith(unit):
+                number_part = size_str[:-len(unit)].strip()
+                try:
+                    return float(number_part) * multiplier
+                except ValueError:
+                    return 0
+        
+        # If no unit found, assume bytes
+        try:
+            return float(size_str)
+        except ValueError:
+            return 0
 
     def close(self):
         self.command_executor.close()
@@ -163,6 +260,60 @@ class DockerSocketManager(DockerManager):
     def get_container_status(self, container_name):
         container = self.client.containers.get(container_name)
         return container.status
+    
+    def get_container_stats(self, container_name) -> dict:
+        """Get container resource statistics using Docker API"""
+        try:
+            container = self.client.containers.get(container_name)
+            if container.status != 'running':
+                return {}
+            
+            stats = container.stats(stream=False)
+            
+            # Calculate CPU percentage
+            cpu_delta = stats['cpu_stats']['cpu_usage']['total_usage'] - stats['precpu_stats']['cpu_usage']['total_usage']
+            system_cpu_delta = stats['cpu_stats']['system_cpu_usage'] - stats['precpu_stats']['system_cpu_usage']
+            number_cpus = len(stats['cpu_stats']['cpu_usage'].get('percpu_usage', []))
+            cpu_percent = 0.0
+            if system_cpu_delta > 0.0 and cpu_delta > 0.0:
+                cpu_percent = (cpu_delta / system_cpu_delta) * number_cpus * 100.0
+            
+            # Calculate memory usage
+            mem_usage = stats['memory_stats']['usage'] - stats['memory_stats'].get('cache', 0)
+            mem_limit = stats['memory_stats']['limit']
+            mem_percent = (mem_usage / mem_limit) * 100.0 if mem_limit > 0 else 0.0
+            
+            # Network stats (sum of all interfaces)
+            rx_bytes = 0
+            tx_bytes = 0
+            if 'networks' in stats:
+                for interface in stats['networks'].values():
+                    rx_bytes += interface.get('rx_bytes', 0)
+                    tx_bytes += interface.get('tx_bytes', 0)
+            
+            # Block I/O stats
+            blkio_read = 0
+            blkio_write = 0
+            if 'blkio_stats' in stats and 'io_service_bytes_recursive' in stats['blkio_stats']:
+                for item in stats['blkio_stats']['io_service_bytes_recursive']:
+                    if item['op'] == 'read':
+                        blkio_read += item['value']
+                    elif item['op'] == 'write':
+                        blkio_write += item['value']
+            
+            return {
+                'cpu_percent': round(cpu_percent, 2),
+                'memory_usage_mb': round(mem_usage / 1024 / 1024, 2),
+                'memory_limit_mb': round(mem_limit / 1024 / 1024, 2),
+                'memory_percent': round(mem_percent, 2),
+                'network_rx_mb': round(rx_bytes / 1024 / 1024, 2),
+                'network_tx_mb': round(tx_bytes / 1024 / 1024, 2),
+                'blkio_read_mb': round(blkio_read / 1024 / 1024, 2),
+                'blkio_write_mb': round(blkio_write / 1024 / 1024, 2)
+            }
+        except Exception as e:
+            logger.error(f"Error getting stats for container {container_name}: {e}")
+            return {}
 
 
 class CommandExecutor(ABC):

--- a/main.py
+++ b/main.py
@@ -136,6 +136,11 @@ class DockerMQTT:
                 self.update_entity_status(container_name, container_state)
                 if container_name not in last_docker_statuses:
                     self.create_entity(container_name)
+                    if self.config.enable_metrics:
+                        self.create_metric_entities(container_name)
+                # Update metrics for running containers
+                if container_state.lower() == "running" and self.config.enable_metrics:
+                    self.update_container_metrics(container_name)
 
             # Update heartbeat file for health check
             self._update_heartbeat()
@@ -175,6 +180,8 @@ class DockerMQTT:
     def delete_entity(self, container_name):
         self.mqtt_client.publish(self._get_topic(container_name, "config"), "")
         self.mqtt_client.publish(self._get_topic(container_name, ""), "")
+        if self.config.enable_metrics:
+            self.delete_metric_entities(container_name)
         logger.debug(f"Configuración eliminada para {container_name}")
 
     def update_entity_status(self, container_name, container_state):
@@ -189,6 +196,115 @@ class DockerMQTT:
     def _get_topic(self, container_name, topic):
         assert topic in ["state", "command", "config", ""]
         return f"homeassistant/switch/{self.prefix}{container_name}/{topic}"
+    
+    def _get_sensor_topic(self, container_name, metric, topic):
+        """Get MQTT topic for sensor entities"""
+        assert topic in ["state", "config", ""]
+        return f"homeassistant/sensor/{self.prefix}{container_name}_{metric}/{topic}"
+    
+    def create_metric_entities(self, container_name):
+        """Create MQTT sensor entities for container metrics"""
+        metrics_config = {
+            'cpu': {
+                'name': f'{container_name} CPU',
+                'unit': '%',
+                'icon': 'mdi:cpu-64-bit',
+                'device_class': None,
+                'state_class': 'measurement'
+            },
+            'memory': {
+                'name': f'{container_name} Memory',
+                'unit': '%',
+                'icon': 'mdi:memory',
+                'device_class': None,
+                'state_class': 'measurement'
+            },
+            'memory_usage': {
+                'name': f'{container_name} Memory Usage',
+                'unit': 'MB',
+                'icon': 'mdi:memory',
+                'device_class': None,
+                'state_class': 'measurement'
+            },
+            'network_rx': {
+                'name': f'{container_name} Network RX',
+                'unit': 'MB',
+                'icon': 'mdi:download-network',
+                'device_class': None,
+                'state_class': 'total_increasing'
+            },
+            'network_tx': {
+                'name': f'{container_name} Network TX',
+                'unit': 'MB',
+                'icon': 'mdi:upload-network',
+                'device_class': None,
+                'state_class': 'total_increasing'
+            },
+            'disk_read': {
+                'name': f'{container_name} Disk Read',
+                'unit': 'MB',
+                'icon': 'mdi:harddisk',
+                'device_class': None,
+                'state_class': 'total_increasing'
+            },
+            'disk_write': {
+                'name': f'{container_name} Disk Write',
+                'unit': 'MB',
+                'icon': 'mdi:harddisk',
+                'device_class': None,
+                'state_class': 'total_increasing'
+            }
+        }
+        
+        for metric, config in metrics_config.items():
+            self.mqtt_client.publish(
+                self._get_sensor_topic(container_name, metric, "config"),
+                json.dumps({
+                    "name": config['name'],
+                    "unique_id": f"{self.prefix}{container_name}_{metric}",
+                    "state_topic": self._get_sensor_topic(container_name, metric, "state"),
+                    "unit_of_measurement": config['unit'],
+                    "icon": config['icon'],
+                    "device_class": config.get('device_class'),
+                    "state_class": config.get('state_class'),
+                    "device": self.device_config
+                }),
+                retain=True
+            )
+            logger.debug(f"Metric entity created for {container_name} - {metric}")
+    
+    def update_container_metrics(self, container_name):
+        """Update container resource metrics"""
+        if not self.config.enable_metrics:
+            return
+        
+        stats = self.docker_manager.get_container_stats(container_name)
+        if not stats:
+            return
+        
+        # Publish each metric
+        metrics_mapping = {
+            'cpu': stats.get('cpu_percent', 0),
+            'memory': stats.get('memory_percent', 0),
+            'memory_usage': stats.get('memory_usage_mb', 0),
+            'network_rx': stats.get('network_rx_mb', 0),
+            'network_tx': stats.get('network_tx_mb', 0),
+            'disk_read': stats.get('blkio_read_mb', 0),
+            'disk_write': stats.get('blkio_write_mb', 0)
+        }
+        
+        for metric, value in metrics_mapping.items():
+            self.mqtt_client.publish(
+                self._get_sensor_topic(container_name, metric, "state"),
+                str(value)
+            )
+    
+    def delete_metric_entities(self, container_name):
+        """Delete MQTT sensor entities for container metrics"""
+        metrics = ['cpu', 'memory', 'memory_usage', 'network_rx', 'network_tx', 'disk_read', 'disk_write']
+        for metric in metrics:
+            self.mqtt_client.publish(self._get_sensor_topic(container_name, metric, "config"), "")
+            self.mqtt_client.publish(self._get_sensor_topic(container_name, metric, ""), "")
 
 
 def main(args):
@@ -280,6 +396,11 @@ if __name__ == "__main__":
         "--entity_prefix",
         help="Prefijo de los dispositivos en Home Assistant",
         default=None,
+    )
+    parser.add_argument(
+        "--enable_metrics",
+        help="Habilitar métricas de contenedores (CPU, memoria, red, disco)",
+        action="store_true",
     )
 
     args = parser.parse_args()

--- a/test_docker_manager.py
+++ b/test_docker_manager.py
@@ -36,6 +36,42 @@ class TestDockerManager(unittest.TestCase):
         manager.stop_container("container1")
         mock_executor.run_command.assert_not_called()
 
+    def test_docker_command_manager_get_container_stats(self):
+        mock_executor = MagicMock()
+        mock_executor.run_command.side_effect = [
+            "running",  # First call to get_container_status
+            "25.5%|1.5GiB / 8GiB|18.75%|1.2MB / 2.3MB|1.5GB / 2.1GB"  # docker stats output
+        ]
+        manager = DockerCommandManager(mock_executor)
+        stats = manager.get_container_stats("container1")
+        
+        self.assertEqual(stats['cpu_percent'], 25.5)
+        self.assertAlmostEqual(stats['memory_usage_mb'], 1536.0, places=0)  # 1.5GiB in MB
+        self.assertEqual(stats['memory_percent'], 18.75)
+        self.assertAlmostEqual(stats['network_rx_mb'], 1.2, places=1)
+        self.assertAlmostEqual(stats['network_tx_mb'], 2.3, places=1)
+        self.assertAlmostEqual(stats['blkio_read_mb'], 1536.0, places=0)  # 1.5GB in MB  
+        self.assertAlmostEqual(stats['blkio_write_mb'], 2150.4, places=0)  # 2.1GB in MB
+
+    def test_docker_command_manager_get_container_stats_not_running(self):
+        mock_executor = MagicMock()
+        mock_executor.run_command.return_value = "stopped"
+        manager = DockerCommandManager(mock_executor)
+        stats = manager.get_container_stats("container1")
+        self.assertEqual(stats, {})
+
+    def test_docker_command_manager_parse_size(self):
+        mock_executor = MagicMock()
+        manager = DockerCommandManager(mock_executor)
+        
+        # Test various size formats
+        self.assertEqual(manager._parse_size("1.5GiB"), 1.5 * 1024**3)
+        self.assertEqual(manager._parse_size("500MB"), 500 * 1024**2)
+        self.assertEqual(manager._parse_size("2GB"), 2 * 1024**3)
+        self.assertEqual(manager._parse_size("1024B"), 1024)
+        self.assertEqual(manager._parse_size(""), 0)
+        self.assertEqual(manager._parse_size("invalid"), 0)
+
     @patch("docker.from_env")
     def test_docker_socket_manager_get_all_statuses(self, mock_docker):
         container1 = MagicMock(spec=docker.models.containers.Container)
@@ -73,6 +109,55 @@ class TestDockerManager(unittest.TestCase):
         manager = DockerSocketManager()
         status = manager.get_container_status("container1")
         self.assertEqual(status, "running")
+
+    @patch("docker.from_env")
+    def test_docker_socket_manager_get_container_stats(self, mock_docker):
+        mock_container = MagicMock()
+        mock_container.status = "running"
+        mock_container.stats.return_value = {
+            'cpu_stats': {
+                'cpu_usage': {'total_usage': 2000000000, 'percpu_usage': [1000000000, 1000000000]},
+                'system_cpu_usage': 4000000000
+            },
+            'precpu_stats': {
+                'cpu_usage': {'total_usage': 1000000000, 'percpu_usage': [500000000, 500000000]},
+                'system_cpu_usage': 2000000000
+            },
+            'memory_stats': {
+                'usage': 1073741824,  # 1GB
+                'cache': 536870912,   # 0.5GB
+                'limit': 2147483648   # 2GB
+            },
+            'networks': {
+                'eth0': {'rx_bytes': 1048576, 'tx_bytes': 2097152}  # 1MB RX, 2MB TX
+            },
+            'blkio_stats': {
+                'io_service_bytes_recursive': [
+                    {'op': 'read', 'value': 10485760},   # 10MB
+                    {'op': 'write', 'value': 20971520}   # 20MB
+                ]
+            }
+        }
+        mock_docker.return_value.containers.get.return_value = mock_container
+        manager = DockerSocketManager()
+        stats = manager.get_container_stats("container1")
+        
+        self.assertEqual(stats['cpu_percent'], 100.0)  # (1B / 2B) * 2 CPUs * 100
+        self.assertEqual(stats['memory_usage_mb'], 512.0)  # (1GB - 0.5GB cache) / 1024 / 1024
+        self.assertEqual(stats['memory_percent'], 25.0)  # (512MB / 2048MB) * 100
+        self.assertEqual(stats['network_rx_mb'], 1.0)  # 1MB
+        self.assertEqual(stats['network_tx_mb'], 2.0)  # 2MB
+        self.assertEqual(stats['blkio_read_mb'], 10.0)  # 10MB
+        self.assertEqual(stats['blkio_write_mb'], 20.0)  # 20MB
+
+    @patch("docker.from_env")
+    def test_docker_socket_manager_get_container_stats_not_running(self, mock_docker):
+        mock_container = MagicMock()
+        mock_container.status = "stopped"
+        mock_docker.return_value.containers.get.return_value = mock_container
+        manager = DockerSocketManager()
+        stats = manager.get_container_stats("container1")
+        self.assertEqual(stats, {})
 
     def test_ssh_command_executor(self):
         executor = SSHCommandExecutor(


### PR DESCRIPTION
- Add get_container_stats method to DockerManager with implementations for socket, SSH, and local modes
- Create MQTT sensor entities for CPU, memory, network, and disk I/O metrics
- Add ENABLE_METRICS configuration option (env var and CLI argument)
- Update main.py to publish and manage metric entities
- Add comprehensive test coverage for metrics functionality
- Support size parsing for docker stats output (GB, GiB, MB, etc.)
- Update documentation with metrics configuration and MQTT topics
- Metrics collected only for running containers during regular updates
- Backward compatible - metrics disabled by default

Container metrics tracked:
- CPU usage percentage
- Memory usage percentage and absolute (MB)
- Network RX/TX (MB)
- Disk read/write (MB)

🤖 Generated with [Claude Code](https://claude.ai/code)